### PR TITLE
Id columns generation

### DIFF
--- a/rctgan/metadata/table.py
+++ b/rctgan/metadata/table.py
@@ -670,7 +670,7 @@ class Table:
     def _make_ids(cls, field_metadata, length):
         field_subtype = field_metadata.get('subtype', 'integer')
         if field_subtype == 'string':
-            regex = field_metadata.get('regex', '[a-zA-Z]+')
+            regex = field_metadata.get('regex', '[a-mo-zA-MO-Z]+')
             generator, max_size = strings_from_regex(regex)
             if max_size < length:
                 raise ValueError((

--- a/rctgan/metadata/table.py
+++ b/rctgan/metadata/table.py
@@ -670,7 +670,7 @@ class Table:
     def _make_ids(cls, field_metadata, length):
         field_subtype = field_metadata.get('subtype', 'integer')
         if field_subtype == 'string':
-            regex = field_metadata.get('regex', '[a-mo-zA-MO-Z]+')
+            regex = field_metadata.get('regex', '[ABCDEFGHJKLMOPQRSTUWYZ]+')
             generator, max_size = strings_from_regex(regex)
             if max_size < length:
                 raise ValueError((

--- a/rctgan/relational/rctgan.py
+++ b/rctgan/relational/rctgan.py
@@ -343,8 +343,9 @@ class RCTGAN:
                 
     def generate_letter_id(self, size):
         liste = []
+        # removed n as nan ids were being generated
         letters = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 
-                   'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+                   'j', 'k', 'l', 'm', 'o', 'p', 'q', 'r',
                    's', 't', 'u', 'v', 'w', 'x', 'y', 'z']
         is_first = True
         boolean =True

--- a/rctgan/relational/rctgan.py
+++ b/rctgan/relational/rctgan.py
@@ -440,7 +440,9 @@ class RCTGAN:
                             all_parents_sampled = False
                     
             if all_parents_sampled == False:
-                break
+                # If all parents were not sampled yet, exit the function
+                # the table will be sampled when all its parents are sampled.
+                return
             
             if parent_name not in tables_transformed.keys():
                 table_transformed = self.transform(parent_name, sampled_data[parent_name])


### PR DESCRIPTION
- Alphanumerical ids can result in ids such as "Na", which can be erroneously detected by pandas as missing values. This can result in `metadata.validate(tables=synthetic_data)` failing and break compatibility with evaluation packages such as SDMetrics or SyntheRela.
- There was an issue when generating foreign-key only issues